### PR TITLE
feat: add a `call` method and command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # gcx
-> An API and CLI for deploying Google Cloud Functions in Node.js.
+> An API and CLI for deploying and calling Google Cloud Functions in Node.js.
 
 [![NPM Version](https://img.shields.io/npm/v/gcx.svg)](https://npmjs.org/package/gcx)
 [![Build Status](https://travis-ci.com/JustinBeckwith/gcx.svg?branch=master)](https://travis-ci.com/JustinBeckwith/gcx)
@@ -12,7 +12,7 @@ $ npm install gcx
 ```
 
 ## Command Line
-`gcx` is a convenient way to deploy Google Cloud Functions.  To use as a command line application:
+`gcx` is a convenient way to deploy and call Google Cloud Functions.  To use as a command line application:
 
 ```sh
 $ npm install --save-dev gcx
@@ -26,7 +26,7 @@ Then from your `package.json`, it's super easy to add a deploy script:
 }
 ```
 
-### Positional arguments
+### Deploy positional arguments
 
 ##### FUNCTION_NAME
 ID of the function or fully qualified identifier for the function. This positional must be specified if any of the other arguments in this group are specified.
@@ -130,13 +130,16 @@ $ gcx deploy myhook
 You can also use this as a regular old API.
 
 ```js
-const {deploy} = require('gcx');
+const {call, deploy} = require('gcx');
 
 async function main() {
   await deploy({
     name: 'my-fn-name',
     region: 'us-central1'
-    ....
+    ...
+  });
+  const res = await call({
+    functionName: 'my-fn-name',
   });
 }
 main().catch(console.error);

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,12 @@ export enum ProgressEvent {
   PACKAGING = 'PACKAGING',
   UPLOADING = 'UPLOADING',
   DEPLOYING = 'DEPLOYING',
+  CALLING = 'CALLING',
   COMPLETE = 'COMPLETE',
+}
+
+export interface CallerOptions extends GoogleAuthOptions {
+  functionName: string;
 }
 
 export interface DeployerOptions extends GoogleAuthOptions {
@@ -46,13 +51,38 @@ export interface DeployerOptions extends GoogleAuthOptions {
 }
 
 /**
- * Class that provides the `deploy` method.
+ * A generic client for GCX.
  */
-export class Deployer extends EventEmitter {
-  _options: DeployerOptions;
+export class GCXClient extends EventEmitter {
   _auth: GoogleAuth;
   _gcf?: cloudfunctions_v1.Cloudfunctions;
 
+  constructor(options?: GoogleAuthOptions) {
+    super();
+    this._auth = new GoogleAuth(options);
+  }
+
+  /**
+   * Provides an authenticated GCF api client.
+   * @private
+   */
+  async _getGCFClient() {
+    if (!this._gcf) {
+      const auth = await this._auth.getClient(
+          {scopes: ['https://www.googleapis.com/auth/cloud-platform']});
+      google.options({auth});
+      this._gcf = google.cloudfunctions('v1');
+    }
+    return this._gcf;
+  }
+}
+
+/**
+ * Class that provides the `deploy` method.
+ */
+export class Deployer extends GCXClient {
+  _options: DeployerOptions;
+  
   constructor(options: DeployerOptions) {
     super();
     this._validateOptions(options);
@@ -265,23 +295,33 @@ export class Deployer extends EventEmitter {
     }
     return ignoreRules;
   }
+}
 
+/**
+ * Class that provides the `call` method.
+ */
+export class Caller extends GCXClient {
   /**
-   * Provides an authenticated GCF api client.
-   * @private
+   * Synchronously call a function.
+   * @param {string} functionName The function to call.
    */
-  async _getGCFClient() {
-    if (!this._gcf) {
-      const auth = await this._auth.getClient(
-          {scopes: ['https://www.googleapis.com/auth/cloud-platform']});
-      google.options({auth});
-      this._gcf = google.cloudfunctions('v1');
-    }
-    return this._gcf;
+  async call(options: CallerOptions) {
+    this.emit(ProgressEvent.STARTING);
+    const gcf = await this._getGCFClient();
+    const fns = gcf.projects.locations.functions;
+    this.emit(ProgressEvent.CALLING);
+    const res = await fns.call({name: options.functionName});
+    this.emit(ProgressEvent.COMPLETE);
+    return res;
   }
 }
 
 export async function deploy(options: DeployerOptions) {
   const deployer = new Deployer(options);
   return deployer.deploy();
+}
+
+export async function call(options: CallerOptions) {
+  const caller = new Caller(options);
+  return caller.call(options);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,7 +82,7 @@ export class GCXClient extends EventEmitter {
  */
 export class Deployer extends GCXClient {
   _options: DeployerOptions;
-  
+
   constructor(options: DeployerOptions) {
     super();
     this._validateOptions(options);

--- a/test/test.ts
+++ b/test/test.ts
@@ -116,8 +116,7 @@ describe('end to end', () => {
   });
 
   it('should call end to end', async () => {
-    const scopes =
-        [mockUploadUrl(), mockUpload(), mockDeploy(), mockPoll(), mockCall()];
+    const scopes = [mockCall()];
     const c = new gcxp.Caller();
     const res = await c.call({functionName: name});
     assert.strictEqual(res.data.result, '{ "data": 42 }');
@@ -166,7 +165,7 @@ function mockExists() {
  */
 function mockCall() {
   return nock('https://cloudfunctions.googleapis.com')
-      .post('/v1/*')
+      .post('/v1/%F0%9F%A6%84:call')
       .reply(200, {
         executionId: 'my-execution-id',
         result: '{ "data": 42 }',

--- a/test/test.ts
+++ b/test/test.ts
@@ -118,7 +118,7 @@ describe('end to end', () => {
   it('should call end to end', async () => {
     const scopes =
         [mockUploadUrl(), mockUpload(), mockDeploy(), mockPoll(), mockCall()];
-    const c = new gcx.Caller();
+    const c = new gcxp.Caller();
     const res = await c.call({functionName: name});
     assert.strictEqual(res.data.result, '{ "data": 42 }');
     scopes.forEach(s => s.done());
@@ -166,8 +166,7 @@ function mockExists() {
  */
 function mockCall() {
   return nock('https://cloudfunctions.googleapis.com')
-      .get(
-          '/v1/projects/el-gato/locations/us-central1/functions/%F0%9F%A6%84:call?alt=json')
+      .post('/v1/*')
       .reply(200, {
         executionId: 'my-execution-id',
         result: '{ "data": 42 }',


### PR DESCRIPTION
Adds a call method for synchronously invoking a Cloud Function.
Fixes #10.

I usually don't like to just duplicate a PR, but I don't think I was in a good state with git, and I may have made a mistake with calling `super`.