### PR TITLE
fix: normalize gcx.call functionName param

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ async function main() {
   });
   const res = await call({
     functionName: 'my-fn-name',
+    ...
   });
 }
 main().catch(console.error);

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ export enum ProgressEvent {
 }
 
 export interface CallerOptions extends GoogleAuthOptions {
+  region?: string;
   functionName: string;
 }
 
@@ -308,9 +309,12 @@ export class Caller extends GCXClient {
   async call(options: CallerOptions) {
     this.emit(ProgressEvent.STARTING);
     const gcf = await this._getGCFClient();
+    const projectId = await this._auth.getProjectId();
+    const region = options.region || 'us-central1';
+    const name = `projects/${projectId}/locations/${region}/function/${options.functionName}`;
     const fns = gcf.projects.locations.functions;
     this.emit(ProgressEvent.CALLING);
-    const res = await fns.call({name: options.functionName});
+    const res = await fns.call({name});
     this.emit(ProgressEvent.COMPLETE);
     return res;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -311,7 +311,8 @@ export class Caller extends GCXClient {
     const gcf = await this._getGCFClient();
     const projectId = await this._auth.getProjectId();
     const region = options.region || 'us-central1';
-    const name = `projects/${projectId}/locations/${region}/function/${options.functionName}`;
+    const name = `projects/${projectId}/locations/${region}/function/${
+        options.functionName}`;
     const fns = gcf.projects.locations.functions;
     this.emit(ProgressEvent.CALLING);
     const res = await fns.call({name});

--- a/test/test.ts
+++ b/test/test.ts
@@ -165,7 +165,8 @@ function mockExists() {
  */
 function mockCall() {
   return nock('https://cloudfunctions.googleapis.com')
-      .post('/v1/projects/el-gato/locations/us-central1/function/%F0%9F%A6%84:call')
+      .post(
+          '/v1/projects/el-gato/locations/us-central1/function/%F0%9F%A6%84:call')
       .reply(200, {
         executionId: 'my-execution-id',
         result: '{ "data": 42 }',

--- a/test/test.ts
+++ b/test/test.ts
@@ -165,7 +165,7 @@ function mockExists() {
  */
 function mockCall() {
   return nock('https://cloudfunctions.googleapis.com')
-      .post('/v1/%F0%9F%A6%84:call')
+      .post('/v1/projects/el-gato/locations/us-central1/function/%F0%9F%A6%84:call')
       .reply(200, {
         executionId: 'my-execution-id',
         result: '{ "data": 42 }',


### PR DESCRIPTION
BREAKING CHANGE:  The `gcx.call` method has been modified to accept a simple non-path based string for the function name.  

#### Previous code
```js
const res = await gcx.call({
  functionName: `projects/${PROJECT_ID}/locations/${LOCATION}/functions/${FUNCTION_NAME}`
});
```

#### New code
```js
const res = await gcx.call({
  functionName: `${FUNCTION_NAME}`
  region: `${LOCATION}`  // defaults to `us-central1`
});
```
