### PR TITLE
feat: Add `data` option to `gcx.call`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,15 +1,17 @@
 import * as archiver from 'archiver';
-import {EventEmitter} from 'events';
 import * as fs from 'fs';
-import {GaxiosResponse} from 'gaxios';
-import globby from 'globby';
-import {GoogleAuth, GoogleAuthOptions} from 'google-auth-library';
-import {cloudfunctions_v1, google} from 'googleapis';
-import fetch from 'node-fetch';
 import * as os from 'os';
 import * as path from 'path';
 import * as util from 'util';
 import * as uuid from 'uuid';
+
+import {GoogleAuth, GoogleAuthOptions} from 'google-auth-library';
+import {cloudfunctions_v1, google} from 'googleapis';
+
+import {EventEmitter} from 'events';
+import {GaxiosResponse} from 'gaxios';
+import fetch from 'node-fetch';
+import globby from 'globby';
 
 const readFile = util.promisify(fs.readFile);
 
@@ -29,6 +31,7 @@ export enum ProgressEvent {
 export interface CallerOptions extends GoogleAuthOptions {
   region?: string;
   functionName: string;
+  data?: string;
 }
 
 export interface DeployerOptions extends GoogleAuthOptions {
@@ -315,7 +318,12 @@ export class Caller extends GCXClient {
         options.functionName}`;
     const fns = gcf.projects.locations.functions;
     this.emit(ProgressEvent.CALLING);
-    const res = await fns.call({name});
+    const res = await fns.call({
+      name,
+      requestBody: {
+        data: options.data,
+      }
+    });
     this.emit(ProgressEvent.COMPLETE);
     return res;
   }

--- a/test/test.ts
+++ b/test/test.ts
@@ -1,11 +1,10 @@
 import * as assert from 'assert';
 import * as fs from 'fs';
+import * as gcx from '../src';
 import * as nock from 'nock';
 import * as path from 'path';
 import * as proxyquire from 'proxyquire';
 import * as util from 'util';
-
-import * as gcx from '../src';
 
 // tslint:disable-next-line variable-name
 const Zip = require('node-stream-zip');
@@ -122,6 +121,14 @@ describe('end to end', () => {
     assert.strictEqual(res.data.result, '{ "data": 42 }');
     scopes.forEach(s => s.done());
   });
+
+  it('should call end to end with data', async () => {
+    const scopes = [mockCallWithData()];
+    const c = new gcxp.Caller();
+    const res = await c.call({functionName: name, data: 142});
+    assert.strictEqual(res.data.result, '{ "data": 142 }');
+    scopes.forEach(s => s.done());
+  });
 });
 
 function mockUpload() {
@@ -170,6 +177,20 @@ function mockCall() {
       .reply(200, {
         executionId: 'my-execution-id',
         result: '{ "data": 42 }',
+        error: null
+      });
+}
+
+/**
+ * @see https://cloud.google.com/functions/docs/reference/rest/v1/projects.locations.functions/call
+ */
+function mockCallWithData() {
+  return nock('https://cloudfunctions.googleapis.com')
+      .post(
+          '/v1/projects/el-gato/locations/us-central1/function/%F0%9F%A6%84:call')
+      .reply(200, {
+        executionId: 'my-execution-id',
+        result: '{ "data": 142 }',
         error: null
       });
 }


### PR DESCRIPTION
Add `data` option to `gcx.call`.

Aside: My editor auto-sorted the imports. Do they need to be reverted?