### PR TITLE
chore: drop support for node 8

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [8, 10, 12, 13]
+        node: [10, 12, 13]
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gcx",
-  "version": "0.0.3",
+  "version": "0.0.0",
   "description": "An API and CLI for deploying Google Cloud Functions in Node.js.",
   "bin": {
     "gcx": "./build/src/cli.js"
@@ -29,7 +29,7 @@
     "serverless"
   ],
   "engines": {
-    "node": ">=8"
+    "node": ">=10"
   },
   "author": "Justin Beckwith <justin.beckwith@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
BREAKING CHANGE: Drops support for node.js 8. 