### PR TITLE
feat: add vpc connector field

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -107,6 +107,12 @@ const cli = meow(
           at a given time. This feature is currently in alpha, available only
           for whitelisted users.
 
+      --vpc-connector=VPC_CONNECTOR
+          Name of VPC connector. Connector name must be in the fully-qualified format of 
+          projects/{project}/locations/{region}/connectors/{connector_name} or {connector_name}    
+      
+          Select a VPC connector to access a Serverless VPC network 
+
       --help
           Show this command.
 
@@ -132,6 +138,7 @@ const cli = meow(
       targetDir: { type: 'string' },
       region: { type: 'string' },
       maxInstances: { type: 'string' },
+      vpcConnector: { type: 'string' },
     },
   }
 );

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,6 +41,7 @@ export interface DeployerOptions extends GoogleAuthOptions {
   memory?: number;
   network?: string;
   maxInstances?: number;
+  vpcConnector?: string;
   timeout?: string;
   triggerHTTP?: boolean;
   triggerTopic?: string;
@@ -161,6 +162,7 @@ export class Deployer extends GCXClient {
     if (opts.description) fields.push('description');
     if (opts.entryPoint) fields.push('entryPoint');
     if (opts.maxInstances) fields.push('maxInstances');
+    if (opts.vpcConnector) fields.push('vpcConnector');
     if (opts.network) fields.push('network');
     if (opts.runtime) fields.push('runtime');
     if (opts.timeout) fields.push('timeout');
@@ -207,6 +209,7 @@ export class Deployer extends GCXClient {
       timeout: this._options.timeout,
       availableMemoryMb: this._options.memory,
       maxInstances: this._options.maxInstances,
+      vpcConnector: this._options.vpcConnector,
     };
     if (this._options.triggerTopic) {
       requestBody.eventTrigger = {


### PR DESCRIPTION
VPC connector is useful to connect into VPC Serverless.
In my case my function connect to redis across a VPC Serverless.