### PR TITLE
docs: remove Snyk badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 [![NPM Version](https://img.shields.io/npm/v/gcx.svg)](https://npmjs.org/package/gcx)
 [![Build Status](https://github.com/JustinBeckwith/gcx/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/JustinBeckwith/gcx/actions)
 [![codecov](https://codecov.io/gh/JustinBeckwith/gcx/branch/main/graph/badge.svg)](https://codecov.io/gh/JustinBeckwith/gcx)
-[![Known Vulnerabilities](https://snyk.io/test/github/JustinBeckwith/gcx/badge.svg)](https://snyk.io/test/github/JustinBeckwith/gcx)
 
 ## Installation
 


### PR DESCRIPTION
## Summary
- remove the Snyk badge from the README badge list

## Testing
- not run (README-only change)