### PR TITLE
ci: auto-merge Dependabot security fixes

### DIFF
--- a/.github/workflows/dependabot-security-automerge.yaml
+++ b/.github/workflows/dependabot-security-automerge.yaml
@@ -1,0 +1,26 @@
+name: Dependabot security auto-merge
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  enable-auto-merge:
+    if: >-
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      !github.event.pull_request.draft &&
+      contains(github.event.pull_request.body, 'disable automated security fix PRs for this repo')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify Dependabot metadata
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+
+      - name: Enable squash auto-merge
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
## What changed

- add a `pull_request_target` workflow for Dependabot security-fix PRs
- verify Dependabot metadata and enable squash auto-merge
- exclude ordinary Dependabot version updates with GitHub's security-update footer marker

## Why

Security patches should merge automatically once branch protection requirements are satisfied, without extending that policy to routine dependency updates.

## Validation

- `git diff --check`
- `actionlint .github/workflows/dependabot-security-automerge.yaml`
