### PR TITLE
fix(docs): replace broken service account link

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ One of the reasons this library exists is to provide a nodejs native deployment 
 
 For this method, you'll need to [create a service account](https://cloud.google.com/docs/authentication/getting-started), and download a key.
 
-1. In the GCP Console, go to the [Create service account key](https://console.cloud.google.com/apis/credentials/serviceaccountkey?_ga=2.44822625.-475179053.1491320180) page.
+1. Follow the Google Cloud instructions to [create a service account key](https://cloud.google.com/iam/docs/keys-create-delete#creating).
 1. From the Service account drop-down list, select New service account.
 1. In the Service account name field, enter a name.
 1. From the Role drop-down list, select Project > Owner.


### PR DESCRIPTION
## Summary

- replace the obsolete Google Cloud Console service-account-key URL in `README.md`
- link to the maintained Google Cloud IAM documentation instead

## Root cause

The repository-wide `links` CI job began failing because the old Console URL returns HTTP 401 to unauthenticated link checks. This failure surfaced on #384 but is unrelated to that dependency update.

## Impact

The README now directs users to maintained instructions, and the link checker can access the destination without authentication.

## Validation

- `npm test` — 39 tests passed
- `npm run lint` — passed
- replacement URL follows its redirect and returns HTTP 200
- `git diff --check` — passed
